### PR TITLE
feat: 공통 버튼 컴포넌트 개발

### DIFF
--- a/src/assets/common/icon-check-filled.svg
+++ b/src/assets/common/icon-check-filled.svg
@@ -1,0 +1,5 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="11" cy="11" r="11" fill="#01D281"/>
+<path d="M6.60001 9.87927L10.2544 13.5337" stroke="white" stroke-width="1.65" stroke-linecap="round"/>
+<path d="M15.9673 7.70001L10.6111 13.2" stroke="white" stroke-width="1.65" stroke-linecap="round"/>
+</svg>

--- a/src/assets/common/icon-check-not-filled.svg
+++ b/src/assets/common/icon-check-not-filled.svg
@@ -1,0 +1,7 @@
+<svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.3">
+<circle cx="11" cy="11" r="10.175" stroke="#01D281" stroke-width="1.65"/>
+<path d="M6.60001 9.87927L10.2544 13.5337" stroke="#01D281" stroke-width="1.65" stroke-linecap="round"/>
+<path d="M15.9673 7.70001L10.6111 13.2" stroke="#01D281" stroke-width="1.65" stroke-linecap="round"/>
+</g>
+</svg>

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -1,0 +1,68 @@
+import styled from 'styled-components'
+import { typo, color } from '../../styles/tokens'
+
+/**
+ * @function Button
+ * @param {boolean} active - 활성/비활성 (기본 true)
+ * @param {string} text - 버튼 텍스트
+ * @param {'full'|number|string} width - 미지정: 100%, 'full': 100%, 숫자: px, 그 외 문자열 그대로
+ * @param {boolean} dismiss - 닫기/보조 액션 스타일 (기본 false)
+ * @param {function} onClick - 클릭 핸들러
+ */
+export default function Button({
+  active = true,
+  text,
+  width,           // undefined면 100%
+  dismiss = false,
+  onClick,
+  ...rest
+}) {
+  return (
+    <StyledButton
+      type="button"
+      $active={active}
+      $width={width}
+      $dismiss={dismiss}
+      onClick={active ? onClick : undefined}
+      disabled={!active}
+      {...rest}
+    >
+      <div>{text}</div>
+    </StyledButton>
+  )
+}
+
+/**
+ * @function resolveWidth
+ * 버튼의 너비를 동적으로 결정하는 함수
+ */
+export const resolveWidth = (w) => {
+  if (w === undefined || w === null) return '100%';      // 기본값: 100%
+  if (w === 'full') return '100%';                       // 명시적 full 
+  if (typeof w === 'number') return `${w}px`;            // 숫자(px)
+  if (typeof w === 'string') return w;                   // '320px', '80%', 등
+  return '100%';
+};
+
+const StyledButton = styled.button`
+  height: 50px;
+  width: ${({ $width }) => resolveWidth($width)};
+  border-radius: 10px;
+  ${typo('button1')};
+
+  /* 상태별 색상 (기본/dismiss) */
+  background-color: ${({ $dismiss }) =>
+    $dismiss ? 'white' : color('brand.primary')};
+  color: ${({ $dismiss }) =>
+    $dismiss ? color('grayscale.600') : 'white'};
+  border: ${({ $dismiss }) =>
+    $dismiss ? `1px solid #DEDEDE` : 'none'};
+
+  /* active=false 시 시각/포인터 비활성 */
+  opacity: ${({ $active }) => ($active ? 1 : 0.3)};
+  pointer-events: ${({ $active }) => ($active ? 'auto' : 'none')};
+  cursor: ${({ $active }) => ($active ? 'pointer' : 'default')};
+
+  /* 기본 인터랙션 */
+  transition: background-color 0.15s ease, opacity 0.15s ease, transform 0.02s ease;
+`

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -12,7 +12,7 @@ import { typo, color } from '../../styles/tokens'
 export default function Button({
   active = true,
   text,
-  width,           // undefined면 100%
+  width='full',         
   dismiss = false,
   onClick,
   ...rest

--- a/src/components/common/ButtonRound.jsx
+++ b/src/components/common/ButtonRound.jsx
@@ -1,0 +1,46 @@
+import styled from "styled-components"
+import { resolveWidth } from "./Button"
+import { typo, color } from "../../styles/tokens"
+
+/**
+ * @function ButtonRound
+ * @param {boolean} filled - 채워진 상태 여부 (기본 true)
+ * @param {string} text - 버튼 텍스트
+ * @param {'full'|number|string} width - 미지정: 100%, 'full': 100%, 숫자: px, 그 외 문자열 그대로(기본값: 'auto')
+ * @param {function} onClick - 클릭 핸들러 (비워진 상태라면 핸들러 실행되지 않음)
+ */
+
+export default function ButtonRound ({ filled=true, text, width='auto', onClick }) {
+    return (
+        <StyledButton
+            type="button"
+            $filled={filled}
+            $width={width}
+            onClick={filled ? onClick : undefined}
+            disabled={!filled}
+        >
+            <div>{text}</div>
+        </StyledButton>
+    )
+}
+
+const StyledButton = styled.button`
+  height: 24px;
+  width: ${({ $width }) => resolveWidth($width)};
+  padding: 0 12px;
+  border-radius: 30px;
+  ${typo('button3')};
+
+  background-color: ${({ $filled }) =>
+    $filled ? color('brand.primary') : 'white'};
+  border: 1.5px solid rgba(1, 210, 129, 0.30);
+  background-clip: padding-box;
+  /* 배경이 보더 영역까지 칠하지 않도록 추가 */
+  color: ${({ $filled }) => ($filled ? 'white' : 'rgba(1, 210, 129, 0.50)')};
+
+  pointer-events: ${({ $filled }) => ($filled ? 'auto' : 'none')};
+  cursor: ${({ $filled }) => ($filled ? 'pointer' : 'default')};
+
+  transition: background-color 0.15s ease, transform 0.02s ease;
+`;
+

--- a/src/components/common/ButtonRound.jsx
+++ b/src/components/common/ButtonRound.jsx
@@ -6,16 +6,18 @@ import { typo, color } from "../../styles/tokens"
  * @function ButtonRound
  * @param {boolean} filled - 채워진 상태 여부 (기본 true)
  * @param {string} text - 버튼 텍스트
- * @param {'full'|number|string} width - 미지정: 100%, 'full': 100%, 숫자: px, 그 외 문자열 그대로(기본값: 'auto')
+ * @param {'full'|number|string} width - 미지정: auto, 'full': 100%, 숫자: px, 그 외 문자열 그대로(기본값: 'auto')
+ * @param {number} height - 미지정: 24, 숫자: px
  * @param {function} onClick - 클릭 핸들러 (비워진 상태라면 핸들러 실행되지 않음)
  */
 
-export default function ButtonRound ({ filled=true, text, width='auto', onClick }) {
+export default function ButtonRound ({ filled=true, text, width='auto', height=24, onClick }) {
     return (
         <StyledButton
             type="button"
             $filled={filled}
             $width={width}
+            $height={height}
             onClick={filled ? onClick : undefined}
             disabled={!filled}
         >
@@ -25,8 +27,8 @@ export default function ButtonRound ({ filled=true, text, width='auto', onClick 
 }
 
 const StyledButton = styled.button`
-  height: 24px;
   width: ${({ $width }) => resolveWidth($width)};
+height: ${({ $height }) => ($height ? `${$height}px` : '24px')};
   padding: 0 12px;
   border-radius: 30px;
   ${typo('button3')};

--- a/src/components/common/ButtonSmall.jsx
+++ b/src/components/common/ButtonSmall.jsx
@@ -1,0 +1,44 @@
+import styled from "styled-components"
+import { resolveWidth } from "./Button"
+import { typo, color } from "../../styles/tokens"
+
+/**
+ * @function ButtonSmall
+ * @param {boolean} active - 활성/비활성 (기본 true)
+ * @param {string} text - 버튼 텍스트
+ * @param {'full'|number|string} width - 미지정: 100%, 'full': 100%, 숫자: px, 그 외 문자열 그대로
+ * @param {function} onClick - 클릭 핸들러
+ */
+
+export default function ButtonSmall ({ active=true, text, width, onClick }) {
+    return (
+        <StyledButton
+            type="button"
+            $active={active}
+            $width={width}
+            onClick={active ? onClick : undefined}
+            disabled={!active}
+        >
+            <div>{text}</div>
+        </StyledButton>
+    )
+}
+
+const StyledButton = styled.button`
+    height: 42px;
+    width: ${({ $width }) => resolveWidth($width)};
+    border-radius: 8px;
+    ${typo('button2')};
+
+    background-color:  white;
+    opacity: ${({ $active }) =>
+        $active ? 1 : 0.3};
+    border: 1px solid ${color('brand.primary')};
+    color: ${color('brand.primary')};
+
+    pointer-events: ${({ $active }) => ($active ? 'auto' : 'none')};
+    cursor: ${({ $active }) => ($active ? 'pointer' : 'default')};
+
+    /* 기본 인터랙션 */
+    transition: background-color 0.15s ease, transform 0.02s ease;
+`

--- a/src/components/common/ButtonSmall.jsx
+++ b/src/components/common/ButtonSmall.jsx
@@ -6,11 +6,11 @@ import { typo, color } from "../../styles/tokens"
  * @function ButtonSmall
  * @param {boolean} active - 활성/비활성 (기본 true)
  * @param {string} text - 버튼 텍스트
- * @param {'full'|number|string} width - 미지정: 100%, 'full': 100%, 숫자: px, 그 외 문자열 그대로
+ * @param {'full'|number|string} width - 미지정: 'full', 'full': 100%, 숫자: px, 그 외 문자열 그대로
  * @param {function} onClick - 클릭 핸들러
  */
 
-export default function ButtonSmall ({ active=true, text, width, onClick }) {
+export default function ButtonSmall ({ active=true, text, width='full', onClick }) {
     return (
         <StyledButton
             type="button"

--- a/src/styles/GlobalStyle.jsx
+++ b/src/styles/GlobalStyle.jsx
@@ -30,6 +30,15 @@ const GlobalStyle = createGlobalStyle`
     min-height: 100vh;
   }
 
+  button {
+    background: inherit;
+    box-shadow: none;
+    border-radius: 0;
+    padding: 0;
+    overflow: visible;
+    cursor: pointer;
+  }
+
   body {
     color: var(--foreground);
     background: var(--background);
@@ -38,6 +47,7 @@ const GlobalStyle = createGlobalStyle`
     min-height: 100vh;
     display: flex;
   }
+
 `;
 
 export default GlobalStyle;

--- a/src/templates/HomeTemplate.jsx
+++ b/src/templates/HomeTemplate.jsx
@@ -8,16 +8,18 @@ export default function HomeTemplate({ featureData = [], onAction }) {
 
       {/* 버튼 계열 - 최소 사용 예시 */}
       <section style={{ display: "grid", gap: 24, marginTop: 24 }}>
-        {/* Button 기본/비활성/사이즈 */}
-        <div>
-          <h2 style={{ margin: "0 0 8px" }}>Button</h2>
-          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
-            <Button text="이용 모드 선택하기" onClick={onAction} />
-            <Button text="비활성" active={false} />
-            <Button text="풀사이즈" onClick={onAction} fullSize />
-            <Button text="240px" onClick={onAction} width={240} />
-          </div>
+          {/* Button 예시 */}
+      <section style={{ marginBottom: 24 }}>
+        <h2>Button</h2>
+        <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+          <Button text="확인하기" onClick={onAction} />
+          <Button text="비활성" active={false} />
+          <Button text="취소하기" dismiss onClick={onAction} />
+          <Button text="풀사이즈" width="full" onClick={onAction} />
+          <Button text="240px" width={240} onClick={onAction} />
         </div>
+      </section>
+
 
         {/* ButtonSmall 기본/비활성/width */}
         <div>
@@ -36,6 +38,7 @@ export default function HomeTemplate({ featureData = [], onAction }) {
           <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
             <ButtonRound text="납부완료" width={'auto'} filled={false} />
             <ButtonRound text="납부하기" width={'auto'} filled onClick={onAction} />
+            <ButtonRound text="높이 다르게" width={'auto'} filled onClick={onAction} height={32} />
           </div>
         </div>
       </section>

--- a/src/templates/HomeTemplate.jsx
+++ b/src/templates/HomeTemplate.jsx
@@ -1,16 +1,44 @@
-export default function HomeTemplate({featureData, onAction}) {
-    return (
+import Button from "../components/common/Button";
+import ButtonSmall from "../components/common/ButtonSmall";
+import ButtonRound from "../components/common/ButtonRound";
+
+export default function HomeTemplate({ featureData = [], onAction }) {
+  return (
+    <div style={{ padding: 24 }}>
+
+      {/* 버튼 계열 - 최소 사용 예시 */}
+      <section style={{ display: "grid", gap: 24, marginTop: 24 }}>
+        {/* Button 기본/비활성/사이즈 */}
         <div>
-            <h1>홈 화면</h1>
-            <ul>
-                {featureData.map((item, index) => (
-                    <li key={index}>
-                        <h2>{item.label}</h2>
-                        <p>{item.description}</p>
-                        <button onClick={onAction}>Action</button>
-                    </li>
-                ))}
-            </ul>
+          <h2 style={{ margin: "0 0 8px" }}>Button</h2>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <Button text="이용 모드 선택하기" onClick={onAction} />
+            <Button text="비활성" active={false} />
+            <Button text="풀사이즈" onClick={onAction} fullSize />
+            <Button text="240px" onClick={onAction} width={240} />
+          </div>
         </div>
-    );
+
+        {/* ButtonSmall 기본/비활성/width */}
+        <div>
+          <h2 style={{ margin: "0 0 8px" }}>ButtonSmall</h2>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <ButtonSmall text="기본" active onClick={onAction} />
+            <ButtonSmall text="비활성" active={false} />
+            <ButtonSmall text="full" width="full" active onClick={onAction} />
+            <ButtonSmall text="160px" width={160} active onClick={onAction} />
+          </div>
+        </div>
+
+        {/* ButtonRound 채움/비움/width */}
+        <div>
+          <h2 style={{ margin: "0 0 8px" }}>ButtonRound</h2>
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+            <ButtonRound text="납부완료" width={'auto'} filled={false} />
+            <ButtonRound text="납부하기" width={'auto'} filled onClick={onAction} />
+          </div>
+        </div>
+      </section>
+    </div>
+  );
 }


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [ ] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [x] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버
close #6 
<!-- ex) close #1 -->

## ✅ 작업 목록

<!-- 이슈 작업한 내용 -->
공통 버튼 컴포넌트 3가지를 개발했습니다.

### 1. Button: 3가지 종류
<img width="496" height="245" alt="Image" src="https://github.com/user-attachments/assets/5d4ed868-9f1a-48c7-80d0-7cc41560d214" />

다양한 너비로 사용할 것 같아 `width` param을 다양하게 넣어도 되게끔 구현했습니다.
`'full'`로 주시면 자동으로 꽉 채우고, `'100%'` 혹은 다른 퍼센티지로 넣어도 되며, 그냥 숫자 `86`으로 주셔도 됩니다.
*추가적으로 `dismiss` 타입 및 속성도 있는데요, 함께 쓰이는 경우가 많은 것 같아 추가해뒀습니다.
<img width="250" height="122" alt="스크린샷 2025-09-03 오전 1 07 44" src="https://github.com/user-attachments/assets/b85fb740-2079-4e0e-9fbe-58d36c29a78c" />


### 2. ButtonSmall: 2가지 종류
<img width="178" height="211" alt="Image" src="https://github.com/user-attachments/assets/09f8ff26-0f2a-4fb3-b818-758ba12ad314" />

활성/비활성 상태로 구분하며, width 속성은 1번과 동일합니다.

### 3. ButtonRound
<img width="144" height="159" alt="Image" src="https://github.com/user-attachments/assets/cfafc503-1029-42bd-bad8-fbed37186d59" />

배경색이 채워진 상태/ 빈 상태로 구분하며 width 속성은 1번과 동일합니다.
높이가 다른 경우가 있을 것 같아 3번 버튼은 `height` 속성이 있고, 기본값은 24px입니다.

### 4. 체크 아이콘
<img width="120" height="181" alt="Image" src="https://github.com/user-attachments/assets/8549756f-1382-43d7-baa8-3dd4297c50b9" />

`assets/common`에 넣어뒀으니 사용하심 됩니다

> 사용법은 임시로 추가해둔 `HomeTemplate`에서 확인하실 수 있습니다! 추가하고 싶은 속성이 있다면 마음껏 넣으세용

## 🍰 논의사항

<!-- 함께 논의하고 싶은 사항, 코드리뷰가 필요한 부분이 있다면 적어주세요. -->

## 📷 ETC
<img width="384" height="681" alt="Image" src="https://github.com/user-attachments/assets/e7a91b3c-474d-4fb8-a403-0edf10e497c1" />
<!-- 스크린샷, GIF 등 참고 자료를 첨부해주세요. -->
