### PR TITLE
feat: TextField, ModeItem 컴포넌트 구현

### DIFF
--- a/src/components/common/ModeItem.jsx
+++ b/src/components/common/ModeItem.jsx
@@ -1,0 +1,31 @@
+// ModeItem.jsx
+import styled, { css } from 'styled-components';
+import { color } from '../../styles/tokens';
+
+export default function ModeItem({ children, selected, onClick, width, height, padding }) {
+  return (
+    <ItemBox selected={selected} onClick={onClick} width={width} height={height} padding={padding}>
+      {children}
+    </ItemBox>
+  );
+}
+
+const ItemBox = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  border-radius: 15px;
+  border: 1px solid ${color('grayscale.300')};
+  cursor: pointer;
+  transition: border 0.2s ease;
+
+  /* ✅ 기본값 + props override */
+  width: ${(props) => props.width || '100%'};
+  height: ${(props) => props.height || '100px'};
+  padding: ${(props) => props.padding || '22px 25px'};
+
+  ${(props) =>
+    props.selected &&
+    css`
+      border: 1px solid ${color('brand.primary')};
+    `}
+`;

--- a/src/components/common/TextField.jsx
+++ b/src/components/common/TextField.jsx
@@ -1,0 +1,45 @@
+// TextField.jsx
+import styled, { css } from 'styled-components';
+import { color, typo } from '../../styles/tokens';
+
+export default function TextField({ placeholder, value, onChange, state, width }) {
+  return (
+    <Input
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+      state={state}
+      width={width}
+    />
+  );
+}
+
+const Input = styled.input`
+  box-sizing: border-box;
+  width: ${(props) => props.width || '100%'};
+  height: 44px;
+  padding: 13px 15px;
+  border-radius: 6px;
+  border: 1px solid var(--Basic-GrayScale-Gray-200, #efefef);
+  background: var(--Basic-GrayScale-Gray-100, #fafafb);
+
+  outline: none;
+  transition: border-color 0.2s ease;
+  ${typo('body2')};
+  color: ${color('grayscale.800')};
+  &::placeholder {
+    color: ${color('grayscale.400')};
+  }
+
+  ${(props) =>
+    props.state === 'error' &&
+    css`
+      border-color: rgba(255, 63, 63, 0.5);
+    `}
+
+  ${(props) =>
+    props.state === 'success' &&
+    css`
+      border-color: rgba(1, 210, 129, 0.5);
+    `}
+`;

--- a/src/components/common/TextField.jsx
+++ b/src/components/common/TextField.jsx
@@ -1,4 +1,3 @@
-// TextField.jsx
 import styled, { css } from 'styled-components';
 import { color, typo } from '../../styles/tokens';
 

--- a/src/templates/RepairTemplate.jsx
+++ b/src/templates/RepairTemplate.jsx
@@ -1,14 +1,9 @@
-import TextField from '../components/common/TextField';
-import RepairBanner from '../components/Repair/RepairBanner';
+import React from 'react';
 
 export default function RepairTemplate() {
   return (
     <>
       <h1>뚝딱뚜깍</h1>
-      <div style={{ padding: '15px' }}>
-        <RepairBanner />
-      </div>
-      <TextField placeholder="입력하시요" state="error" />
     </>
   );
 }

--- a/src/templates/RepairTemplate.jsx
+++ b/src/templates/RepairTemplate.jsx
@@ -1,12 +1,14 @@
+import TextField from '../components/common/TextField';
 import RepairBanner from '../components/Repair/RepairBanner';
 
 export default function RepairTemplate() {
   return (
-    <div>
+    <>
       <h1>뚝딱뚜깍</h1>
       <div style={{ padding: '15px' }}>
         <RepairBanner />
       </div>
-    </div>
+      <TextField placeholder="입력하시요" state="error" />
+    </>
   );
 }


### PR DESCRIPTION
## 📝 PR 유형

- [x] ✨ feat: 새로운 기능
- [ ] 🐛 fix: 버그 수정
- [ ] ♻️ refactor: 코드 리팩토링
- [x] 🎨 design: CSS 등 사용자 UI 디자인 변경
- [ ] 💎 style: 코드 포맷팅, 코드 변경이 없는 경우
- [ ] 📦 chore: 빌드 업무 수정, 패키지 매니저 설정, 자잘한 코드 수정
- [ ] 💬 comment: 주석 추가 및 변경
- [ ] 📚 docs: 문서 수정
- [ ] 🚑 !HOTFIX: 급하게 치명적인 버그를 고치는 경우
- [ ] 🚀 perf: 성능 개선
- [ ] ETC

## 🔔 관련된 이슈 넘버

close #8 

## ✅ 작업 목록

<img width="606" height="251" alt="스크린샷 2025-09-03 오후 4 21 22" src="https://github.com/user-attachments/assets/ba8b3281-6b51-4a48-8d77-9b9c1b664788" />

- [x] : TextField 컴포넌트 구현
- [x] : ModeItem 컴포넌트 구현

## 🍰 논의사항

<h2>1. TextField 사용 가이드</h2>
<h3>컴포넌트 목적</h3>
<ul>
<li>단일 줄 텍스트 입력. 기본/에러/성공 상태를 border 컬러로 표현하고, 토큰(<code>color</code>, <code>typo</code>)을 사용해 디자인 시스템을 준수</li>
</ul>
<h3>Props</h3>

Prop | Type | Required | Default | 설명
-- | -- | -- | -- | --
value | string | ✅ | — | controlled input 값
onChange | (e) => void | ✅ | — | 값 변경 핸들러
placeholder | string | ❌ | "" | 플레이스홀더 텍스트
state | `"default" | "error" | "success"` | ❌
width | string | ❌ | "100%" | 너비. 예: "320px", "50%"


<ul>
<li>레이아웃 크기(<code>width</code>, <code>height</code>, <code>padding</code>)는 props로 조절 가능 하며 default 값은 아래와 같음
<ul>
<li>width: 100%</li>
<li>height: 100px</li>
<li>padding : 22px 25px;</li>
</ul>
</li>
</ul>

<h3>사용예시</h3>

```jsx
import { useState } from "react";
import TextField from "@/components/common/TextField";

export default function ExampleBasic() {
  const [name, setName] = useState("");

  return (
    <div style={{ display: "grid", gap: 12, width: 360 }}>
      {/* 기본 상태 */}
      <TextFieldplaceholder="이름을 입력하세요"
        value={name}
        onChange={(e) => setName(e.target.value)}
      />

      {/* 너비 지정 */}
      <TextFieldplaceholder="320px 고정 너비"
        value={name}
        onChange={(e) => setName(e.target.value)}
        width="320px"
      />
    </div>
  );
}

```
<h2>2. ModeItem 사용 가이드</h2>
<h3>컴포넌트 목적</h3>
<ul>
<li>선택 가능한 박스 UI. 특정 모드를 선택했을 때 초록색(<code>brand.primary</code>) 테두리로 강조</li>
</ul>
<h3>Props</h3>

Prop | Type | Required | Default | 설명
-- | -- | -- | -- | --
children | ReactNode | ✅ | — | 박스 내부에 들어갈 콘텐츠 (텍스트, 아이콘 등)
selected | boolean | ❌ | false | 선택 여부. true일 경우 테두리가 초록색으로 변경
onClick | function | ❌ | — | 클릭 이벤트 핸들러
width | string | ❌ | "100%" | 박스 너비. 예: "320px", "50%"
height | string | ❌ | "100px" | 박스 높이
padding | string | ❌ | "22px 25px" | 내부 여백


<ul>
<li>레이아웃 크기(<code>width</code>, <code>height</code>, <code>padding</code>)는 props로 조절 가능 하며 default 값은 아래와 같음
<ul>
<li>width: 100%</li>
<li>height: 100px</li>
<li>padding : 22px 25px;</li>
</ul>
</li>
</ul>

<h3>사용예시</h3>

```jsx
import { useState } from "react";
import ModeItem from "@/components/common/ModeItem";

export default function ExampleBasic() {
  const [selected, setSelected] = useState(null);

  return (
    <div style={{ display: "flex", flexDirection: "column", gap: 12, width: 360 }}>
      {/* 선택 안 된 상태 */}
      <ModeItem selected={selected === 1} onClick={() => setSelected(1)}>
        모드 1
      </ModeItem>

      {/* 선택된 상태 */}
      <ModeItem selected={selected === 2} onClick={() => setSelected(2)}>
        모드 2
      </ModeItem>
    </div>
  );
}
```

- Mode 선택이 필요한 UI에서 useState 선언과 함께 사용하면 됩니다. selecter props로 전달하여 사용하면 됩니다.
- 필요한 버튼 개수에 따라 selected === 3,4,5… 계속 붙여서 쓰면 됩니다.
- ModeItem 내부 콘텐츠는 children props로 전달되기 때문에 <ModeItem> 안에 원래 스타일링 하던대로 스타일링 해서 넣어서 쓰면 됩니다.
<img width="1071" height="519" alt="스크린샷 2025-09-03 오후 9 53 05" src="https://github.com/user-attachments/assets/70887952-0122-4c88-abf2-b504a1061106" />


## 📷 ETC


